### PR TITLE
fix loader->register

### DIFF
--- a/app/Bootstrap.php
+++ b/app/Bootstrap.php
@@ -22,8 +22,8 @@ class Bootstrap
 
         $loader = new \Phalcon\Loader();
         $loader->registerNamespaces($config->loader->namespaces->toArray());
-        $loader->register();
         $loader->registerDirs(array(APPLICATION_PATH . "/plugins/"));
+        $loader->register();
 
 
         $db = new \Phalcon\Db\Adapter\Pdo\Mysql(array(


### PR DESCRIPTION
В класса Phalcon\Loader метод register() должно вызываться последним, это сам факт регистрации всех объявленных ранее окружений.
