### PR TITLE
fix fatal error on tree category update

### DIFF
--- a/app/modules/Tree/Model/Category.php
+++ b/app/modules/Tree/Model/Category.php
@@ -8,6 +8,8 @@ namespace Tree\Model;
 
 use Application\Mvc\Model\Model;
 use Phalcon\Mvc\Model\Validator\Uniqueness;
+use Phalcon\Validation;
+use Phalcon\Validation\Validator\Uniqueness as UniquenessValidator;
 
 class Category extends Model
 {
@@ -43,14 +45,14 @@ class Category extends Model
 
     public function validation()
     {
-        $this->validate(new Uniqueness(
-            [
-                "field"   => "slug",
-                "message" => "Category with slug '" . $this->slug . "' is already exists. Take another title"
-            ]
+        $validator = new Validation();
+        $validator->add('slug', new UniquenessValidator(
+           [
+               "model"   => $this,
+               "message" => "Category with slug '" . $this->slug . "' is already exists. Take another title"
+           ]
         ));
-
-        return $this->validationHasFailed() != true;
+        return $this->validate($validator);
     }
 
     public function beforeCreate()


### PR DESCRIPTION
In admin/tree categories (for example */public/tree/admin/edit/15) when you press [Save] button error will occure:

> Catchable fatal error: Argument 1 passed to Phalcon\Mvc\Model::validate() must implement interface Phalcon\ValidationInterface, instance of Phalcon\Mvc\Model\Validator\Uniqueness given in C:\usr\Apache24\htdocs\yona\app\modules\Tree\Model\Category.php on line 53

