### PR TITLE
set default config to staticWidget

### DIFF
--- a/app/modules/Admin/Model/AdminUser.php
+++ b/app/modules/Admin/Model/AdminUser.php
@@ -33,7 +33,7 @@ class AdminUser extends \Phalcon\Mvc\Model
 
     public function initialize()
     {
-        require_once __DIR__ . '/../../../../vendor/password.php';
+        require_once __DIR__ . '/../../../plugins/password.php';
     }
 
     public function setCheckboxes($post)

--- a/app/plugins/password.php
+++ b/app/plugins/password.php
@@ -217,6 +217,3 @@ if (!defined('PASSWORD_DEFAULT')) {
         return $status === 0;
     }
 }
-
-
-


### PR DESCRIPTION
I adding default option in staticWidget without hard code as currently 

```
public function staticWidget($id, $params) {		      
    $mergeConfig = array_merge(self::StaticWidgetDefaultOptions, $params);
    $widget = \Widget\Model\Widget::findFirst(["id='{$id}'", "cache" => ["lifetime" => $mergeConfig["lifetime"], "key" => HOST_HASH . md5("Widget::findFirst({$id})")]]);

... 
```