### PR TITLE
Updates to Exceptions and final output in Bootstrap.php

### DIFF
--- a/app/Bootstrap.php
+++ b/app/Bootstrap.php
@@ -28,8 +28,8 @@ class Bootstrap
         $loader = new \Phalcon\Loader();
         $loader->registerNamespaces($config->loader->namespaces->toArray());
         $loader->registerDirs([APPLICATION_PATH . "/plugins/"]);
+        $loader->registerFiles([APPLICATION_PATH . '/../vendor/autoload.php']);
         $loader->register();
-        require_once APPLICATION_PATH . '/../vendor/autoload.php';
 
         // Database
         $db = new \Phalcon\Db\Adapter\Pdo\Mysql([
@@ -312,16 +312,15 @@ class Bootstrap
                 $view->e = $e;
 
                 if ($e instanceof \Phalcon\Mvc\Dispatcher\Exception) {
-                    $response->setHeader(404, 'Not Found');
+                    $response->setStatusCode(404, 'Not Found');
                     $view->partial('error/error404');
                 } else {
-                    $response->setHeader(503, 'Service Unavailable');
+                    $response->setStatusCode(503, 'Service Unavailable');
                     $view->partial('error/error503');
                 }
-                $response->sendHeaders();
-                echo $response->getContent();
-                return;
 
+                echo $response->send()->getContent();
+                return;
             }
         }
 
@@ -360,9 +359,7 @@ class Bootstrap
             $response->setContent($view->getContent());
         }
 
-        $response->sendHeaders();
-
-        echo $response->getContent();
+        echo $response->send()->getContent();
     }
 
 }

--- a/app/Bootstrap.php
+++ b/app/Bootstrap.php
@@ -92,7 +92,8 @@ class Bootstrap
         $application->setDI($di);
 
         // Main dispatching process
-        $this->dispatch($di);
+        $response = $this->dispatch($di);
+        $response->send();
 
     }
 
@@ -319,8 +320,7 @@ class Bootstrap
                     $view->partial('error/error503');
                 }
 
-                $response->send();
-                return;
+                return $response;
             }
         }
 
@@ -357,7 +357,7 @@ class Bootstrap
             $response->setContent($view->getContent());
         }
 
-        $response->send();
+        return $response;
     }
 
 }

--- a/app/Bootstrap.php
+++ b/app/Bootstrap.php
@@ -332,8 +332,6 @@ class Bootstrap
 
         $view->finish();
 
-        $response = $di['response'];
-
         // AJAX
         $request = $di['request'];
         $_ajax = $request->getQuery('_ajax');

--- a/app/Bootstrap.php
+++ b/app/Bootstrap.php
@@ -319,7 +319,7 @@ class Bootstrap
                     $view->partial('error/error503');
                 }
 
-                echo $response->send()->getContent();
+                $response->send();
                 return;
             }
         }
@@ -359,7 +359,7 @@ class Bootstrap
             $response->setContent($view->getContent());
         }
 
-        echo $response->send()->getContent();
+        $response->send();
     }
 
 }


### PR DESCRIPTION
While testing exception handling only 200 were sent. Upon inspection found the right way to handle the headers in response so it really does send 404 or 503 to the client. Also moved "require" for vendor/autoload.php file into the loader. For consistency reasons I also updated the final output of dispatch(). (Upon testing $response->send() sends the headers so no need for explicit call of $response->sendHeaders())